### PR TITLE
DataChannel の接続タイムアウト時間を変更

### DIFF
--- a/src/sora/sora_client.h
+++ b/src/sora/sora_client.h
@@ -39,7 +39,7 @@ struct SoraClientConfig {
   int spotlight_number = 0;
   bool simulcast = false;
   bool data_channel_signaling = false;
-  int data_channel_signaling_timeout = 30;
+  int data_channel_signaling_timeout = 180;
   bool ignore_disconnect_websocket = false;
   bool close_websocket = true;
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -163,7 +163,7 @@ void Util::ParseArgs(std::vector<std::string>& args,
       ->transform(CLI::CheckedTransformer(bool_map, CLI::ignore_case));
   app.add_option("--sora-data-channel-signaling-timeout",
                  config.sora_data_channel_signaling_timeout,
-                 "Timeout for Data Channel in seconds (default: 30)")
+                 "Timeout for Data Channel in seconds (default: 180)")
       ->check(CLI::PositiveNumber);
   app.add_option("--sora-ignore-disconnect-websocket",
                  config.sora_ignore_disconnect_websocket,

--- a/src/zakuro.h
+++ b/src/zakuro.h
@@ -43,7 +43,7 @@ struct ZakuroConfig {
   bool sora_spotlight = false;
   int sora_spotlight_number = 0;
   bool sora_data_channel_signaling = false;
-  int sora_data_channel_signaling_timeout = 30;
+  int sora_data_channel_signaling_timeout = 180;
   bool sora_ignore_disconnect_websocket = false;
   bool sora_close_websocket = true;
   boost::json::value sora_metadata;


### PR DESCRIPTION
- util.cpp の タイムアウト説明の default: 30 を default: 180 に修正
- zakuro.h の sora_data_channel_signaling_timeout を 30 から 180 に修正
- sora_client.h の data_channel_signaling_timeout を 30 から 180 に修正