### PR TITLE
廃止になった --sora-audio-opus-params-clock-rate を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [FIX] 廃止になった `--sora-audio-opus-params-clock-rate` を削除する
+    - @torikizi
 - [FIX] "data-channels" の "interval" 項目を指定するとエラーになる問題を修正
     - @sile
 - [UPDATE] `CLI11` を `2.3.0` に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,12 @@
 
 ## develop
 
+- [UPDATE] `CLI11` を `2.3.0` に上げる
+    - @voluntas
 - [FIX] 廃止になった `--sora-audio-opus-params-clock-rate` を削除する
     - @torikizi
 - [FIX] "data-channels" の "interval" 項目を指定するとエラーになる問題を修正
     - @sile
-- [UPDATE] `CLI11` を `2.3.0` に上げる
-    - @voluntas
 
 ## 2022.7.0 (2022-10-06)
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ Options:
                               Video bit rate
   --sora-audio-bit-rate INT:INT in [0 - 510]
                               Audio bit rate
-  --sora-audio-opus-params-clock-rate INT:INT in [1600 - 48000]
-                              OPUS clock rate
   --sora-multistream BOOLEAN:value in {false->0,true->1} OR {0,1}
                               Use multistream (default: false)
   --sora-simulcast BOOLEAN:value in {false->0,true->1} OR {0,1}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -180,9 +180,6 @@ void Util::ParseArgs(const std::vector<std::string>& cargs,
   app.add_option("--sora-audio-bit-rate", config.sora_audio_bit_rate,
                  "Audio bit rate")
       ->check(CLI::Range(0, 510));
-  app.add_option("--sora-audio-opus-params-clock-rate",
-                 config.sora_audio_opus_params_clock_rate, "OPUS clock rate")
-      ->check(CLI::Range(1600, 48000));
   app.add_option("--sora-multistream", config.sora_multistream,
                  "Use multistream (default: false)")
       ->transform(CLI::CheckedTransformer(bool_map, CLI::ignore_case));
@@ -525,7 +522,6 @@ std::vector<std::vector<std::string>> Util::NodeToArgs(const YAML::Node& inst) {
       DEF_STRING(sora, "sora-", "audio-codec-type");
       DEF_INTEGER(sora, "sora-", "video-bit-rate");
       DEF_INTEGER(sora, "sora-", "audio-bit-rate");
-      DEF_INTEGER(sora, "sora-", "audio-opus-params-clock-rate");
       DEF_BOOLEAN(sora, "sora-", "multistream");
       DEF_BOOLEAN(sora, "sora-", "simulcast");
       DEF_STRING(sora, "sora-", "simulcast-rid");

--- a/src/zakuro.cpp
+++ b/src/zakuro.cpp
@@ -316,8 +316,6 @@ int Zakuro::Run() {
   sora_config.audio_codec_type = config_.sora_audio_codec_type;
   sora_config.video_bit_rate = config_.sora_video_bit_rate;
   sora_config.audio_bit_rate = config_.sora_audio_bit_rate;
-  sora_config.audio_opus_params_clock_rate =
-      config_.sora_audio_opus_params_clock_rate;
   sora_config.metadata = config_.sora_metadata;
   sora_config.signaling_notify_metadata =
       config_.sora_signaling_notify_metadata;

--- a/src/zakuro.h
+++ b/src/zakuro.h
@@ -54,8 +54,6 @@ struct ZakuroConfig {
   // 0 の場合ビットレートは Sora 側で決める
   int sora_video_bit_rate = 0;
   int sora_audio_bit_rate = 0;
-  // opus の設定
-  int sora_audio_opus_params_clock_rate = 0;
   std::string sora_role = "";
   bool sora_multistream = false;
   bool sora_simulcast = false;


### PR DESCRIPTION
Sora 2021.2.0 にて opus_params の clock_rate は廃止されたため、削除します。