### PR TITLE
パッケージのフォルダ名を zakuro-{version} に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,8 +33,9 @@
     - @sile
 - [FIX] クライアント名が消えてたのを修正
     - @melpon
-- [FIX] パッケージを展開した際の名前が `zakuro` になってしまっていたのを `zakuro-{version}_{platform}` にする
+- [FIX] パッケージを展開した際の名前が `zakuro` になってしまっていたのを `zakuro-{version}` にする
     - @melpon
+    - @miosakuma
 
 ## 2022.7.1 (2022-10-31)
 

--- a/run.py
+++ b/run.py
@@ -749,7 +749,7 @@ def main():
 
     if args.package:
         mkdir_p(package_dir)
-        zakuro_package_dir = os.path.join(package_dir, f'zakuro-{zakuro_version}_{args.target}')
+        zakuro_package_dir = os.path.join(package_dir, f'zakuro-{zakuro_version}')
         rm_rf(zakuro_package_dir)
         rm_rf(os.path.join(package_dir, 'zakuro.env'))
 
@@ -775,7 +775,7 @@ def main():
             archive_name = f'zakuro-{zakuro_version}_{args.target}.tar.gz'
             archive_path = os.path.join(package_dir, archive_name)
             with tarfile.open(archive_path, 'w:gz') as f:
-                for file in enum_all_files(f'zakuro-{zakuro_version}_{args.target}', '.'):
+                for file in enum_all_files(f'zakuro-{zakuro_version}', '.'):
                     f.add(name=file, arcname=file)
             with open(os.path.join(package_dir, 'zakuro.env'), 'w') as f:
                 f.write("CONTENT_TYPE=application/gzip\n")


### PR DESCRIPTION
パッケージのフォルダ名 `zakuro-{version}_{platform}` を `zakuro-{version}` に変更する対応です。

- 以前のめるぽんさんのフォルダ名修正（ https://github.com/shiguredo/zakuro/commit/232087d16549725d60726d451e6f7d556176d28a ）を再度修正する内容です 
- 最終的にパッケージのフォルダ、ファイル名は以下の通りになります
    - ファイル名 `zakuro-{version}_{platform}.tar.gz`
    - 展開したフォルダ名 `zakuro-{version}`
- CHANGES.md の内容は以前のめるぽんさんの修正内容を修正するようにしました
- Github Actions の結果を確認して大丈夫そうです
