### PR TITLE
VP9, AV1 もサイマルキャストが利用可能と可能となるよう入力チェックを変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
     - @melpon
 - [UPDATE] actions/create-release と actions/upload-release を softprops/action-gh-release に変更する
     - @melpon
+- [UPDATE] VP9, AV1 もサイマルキャストが利用可能と可能となるよう入力チェックを変更する
+    - @miosakuma
 - [ADD] Ubuntu 22.04 x86_64 のビルドを追加
     - @melpon
 - [ADD] `--sora-client-id` および `--sora-bundle-id` オプションを追加

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -353,8 +353,10 @@ void Util::ParseArgs(const std::vector<std::string>& cargs,
   // サイマルキャストは VP8 か H264 のみで動作する
   if (config.sora_video && config.sora_simulcast &&
       config.sora_video_codec_type != "VP8" &&
+      config.sora_video_codec_type != "VP9" &&
+      config.sora_video_codec_type != "AV1" &&
       config.sora_video_codec_type != "H264") {
-    std::cerr << "Simulcast works only --sora-video-codec=VP8 or H264."
+    std::cerr << "Simulcast works only --sora-video-codec=VP8, VP9, AV1 or H264."
               << std::endl;
     std::exit(1);
   }


### PR DESCRIPTION
`VP9`, `AV1` もサイマルキャストが利用できるようにサイマルキャストの入力チェックに `VP9`, `AV1` を追加しました。

変更箇所であるサイマルキャストの映像コーデックチェックより前に以下の映像コーデックチェックがあるため、現時点では今回変更したチェック箇所でエラーが発生することはありません。
今後 `sora_video_codec_type` の種類が増えてサイマルキャストのチェックと内容が一致しなくなっても問題ないようにこのような修正にしました。

```
config.sora_video_codec_type,
                 "Video codec for send")
      ->check(CLI::IsMember({"", "VP8", "VP9", "AV1", "H264"}));
```