### PR TITLE
Github Actions の upload-artifact / download-artifact を v4 に上げる

### DIFF
--- a/.github/actions/download/action.yml
+++ b/.github/actions/download/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.platform }}.env
         path: ${{ inputs.platform }}.env
@@ -22,7 +22,7 @@ runs:
         echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
         echo "$PACKAGE_NAME/$PACKAGE_NAME" >> package_paths.env
       id: env
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ steps.env.outputs.package_name }}
         path: ${{ steps.env.outputs.package_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,12 @@ jobs:
           echo "name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
         id: package_name
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package_name.outputs.name }}
           path: _package/${{ matrix.name }}/release/${{ steps.package_name.outputs.name }}
       - name: Upload Environment
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}.env
           path: _package/${{ matrix.name }}/release/zakuro.env

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,12 @@
   - @melpon
 - [UPDATE] run.py に定義されていた関数を buildbase.py に移動する
   - @melpon
+- [UPDATE] Github Actions の actions/checkout , actions/upload-artifact , actions/download-artifact をアップデート
+  - Node.js 16 の Deprecated に伴うアップデート
+    - actions/checkout@v3 から actions/checkout@v4 にアップデート
+    - actions/upload-artifact@v3 から actions/upload-artifact@v4 にアップデート
+    - actions/download-artifact@v3 から actions/download-artifact@v4 にアップデート
+  - @miosakuma @torikizi
 - [FIX] VideoCodec は Protected のため CreateVideoCodec に修正
   - m117.5938.2.0 へのアップデートに伴う修正
   - @torikizi


### PR DESCRIPTION
Node16 廃止に伴う Github Actions のアップデート対応。
CI が通り次第マージします。