### PR TITLE
multistream を削除

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   - @melpon
 - [CHANGE] Ubuntu 20.04 のビルドを削除
   - @melpon
+- [CHANGE] multistream のオプションを削除
+  - @torikizi
 - [UPDATE] Sora C++ SDK を `2024.8.0` に上げる
   - それに伴って以下のライブラリのバージョンも上げる
   - libwebrtc のバージョンを `m128.6613.2.0` に上げる

--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ Options:
                               Video bit rate (default: none)
   --sora-audio-bit-rate INT:INT in [0 - 510]
                               Audio bit rate (default: none)
-  --sora-multistream BOOLEAN:value in {false->0,true->1} OR {0,1}
-                              Use multistream (default: false)
   --sora-simulcast BOOLEAN:value in {false->0,true->1} OR {0,1}
                               Use simulcast (default: false)
   --sora-simulcast-rid TEXT   Simulcast rid (default: none)

--- a/doc/USE.md
+++ b/doc/USE.md
@@ -32,7 +32,6 @@ $ ./zakuro \
     --sora-channel-id zakuro-test \
     --sora-video-codec-type VP8 \
     --sora-video-bit-rate 1000 \
-    --sora-multistream true \
     --resolution 640x480 \
     --fake-capture-device \
     --vcs 5
@@ -119,7 +118,6 @@ zakuro:
         channel-id: "sora"
         role: "sendrecv"
         video-codec-type: VP8
-        multistream: true
         spotlight: true
         simulcast: true
     - name: zakuro2
@@ -129,7 +127,6 @@ zakuro:
         channel-id: "sora"
         role: "sendrecv"
         video-codec-type: VP8
-        multistream: true
         spotlight: true
         simulcast: true
 ```
@@ -173,7 +170,6 @@ zakuro:
         signaling-url: "wss://sora.example.com/signaling"
         channel-id: sora
         role: sendrecv
-        multistream: true
         data-channel-signaling: true
         data-channels:
           - label: "#test"
@@ -206,5 +202,4 @@ zakuro:
           - "wss://sora3.example.com/signaling"
         channel-id: sora
         role: sendrecv
-        multistream: true
 ```

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -199,9 +199,6 @@ void Util::ParseArgs(const std::vector<std::string>& cargs,
   app.add_option("--sora-audio-bit-rate", config.sora_audio_bit_rate,
                  "Audio bit rate (default: none)")
       ->check(CLI::Range(0, 510));
-  app.add_option("--sora-multistream", config.sora_multistream,
-                 "Use multistream (default: false)")
-      ->transform(CLI::CheckedTransformer(bool_map, CLI::ignore_case));
   app.add_option("--sora-simulcast", config.sora_simulcast,
                  "Use simulcast (default: false)")
       ->transform(CLI::CheckedTransformer(bool_map, CLI::ignore_case));
@@ -545,7 +542,6 @@ std::vector<std::vector<std::string>> Util::NodeToArgs(const YAML::Node& inst) {
       DEF_STRING(sora, "sora-", "audio-codec-type");
       DEF_INTEGER(sora, "sora-", "video-bit-rate");
       DEF_INTEGER(sora, "sora-", "audio-bit-rate");
-      DEF_BOOLEAN(sora, "sora-", "multistream");
       DEF_BOOLEAN(sora, "sora-", "simulcast");
       DEF_STRING(sora, "sora-", "simulcast-rid");
       DEF_BOOLEAN(sora, "sora-", "spotlight");

--- a/src/zakuro.cpp
+++ b/src/zakuro.cpp
@@ -391,7 +391,6 @@ int Zakuro::Run() {
   sora_config.signaling_notify_metadata =
       config_.sora_signaling_notify_metadata;
   sora_config.role = config_.sora_role;
-  sora_config.multistream = config_.sora_multistream;
   sora_config.simulcast = config_.sora_simulcast;
   sora_config.simulcast_rid = config_.sora_simulcast_rid;
   sora_config.spotlight = config_.sora_spotlight;

--- a/src/zakuro.h
+++ b/src/zakuro.h
@@ -65,7 +65,6 @@ struct ZakuroConfig {
   int sora_video_bit_rate = 0;
   int sora_audio_bit_rate = 0;
   std::string sora_role = "";
-  bool sora_multistream = false;
   bool sora_simulcast = false;
   std::string sora_simulcast_rid;
   bool sora_spotlight = false;


### PR DESCRIPTION
マルチストリームオプションを削除しました。
ローカルビルドを実行して、Sora の設定を利用するように変更されていることを確認しました。
合わせてドキュメントの方も削除しています。

----

This pull request focuses on removing the `multistream` option from various parts of the codebase, including documentation and implementation files. The most important changes include updates to the documentation, removal of the `multistream` option from the command-line interface, and corresponding changes in the configuration and implementation files.

### Documentation Updates:
* Removed the `multistream` option from `CHANGES.md`, `README.md`, and several sections in `doc/USE.md`. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R20-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-L123) [[3]](diffhunk://#diff-abe0b25fa6145a39359775f813d4adac9c0f6f09af0418ce61950ced2dcceebbL35) [[4]](diffhunk://#diff-abe0b25fa6145a39359775f813d4adac9c0f6f09af0418ce61950ced2dcceebbL122) [[5]](diffhunk://#diff-abe0b25fa6145a39359775f813d4adac9c0f6f09af0418ce61950ced2dcceebbL132) [[6]](diffhunk://#diff-abe0b25fa6145a39359775f813d4adac9c0f6f09af0418ce61950ced2dcceebbL176) [[7]](diffhunk://#diff-abe0b25fa6145a39359775f813d4adac9c0f6f09af0418ce61950ced2dcceebbL209)

### Command-Line Interface:
* Removed the `--sora-multistream` option from `src/util.cpp`. [[1]](diffhunk://#diff-449acf764318b0ca96972daf8d28a28af79ad2c3381044851f2953792fcd8eefL202-L204) [[2]](diffhunk://#diff-449acf764318b0ca96972daf8d28a28af79ad2c3381044851f2953792fcd8eefL548)

### Configuration and Implementation:
* Removed the `multistream` field from `ZakuroConfig` in `src/zakuro.h` and updated its usage in `src/zakuro.cpp`. [[1]](diffhunk://#diff-09fcbde26f3f370a291e7c74d9049ef424cc05a502ac64ac702ad2c3027f65d4L394) [[2]](diffhunk://#diff-b51e47cde714d3f5cddf1b28cf3e86e3729af06b507fe3ef6496d42df73ba6b3L68)