### PR TITLE
[doc] Ubuntu 20.04 のビルド方法を削除して、24.04 を追加する

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -12,17 +12,6 @@ $ git clone git@github.com:shiguredo/zakuro.git
 $ sudo apt install libxext-dev libx11-dev libdrm-dev libva-dev pkg-config python3
 ```
 
-## Ubuntu 20.04 (x86_64) 向けバイナリを作成する
-
-build ディレクトリ以下で `python3 run.py ubuntu-20.04_x86_64` と打つことで Zakuro の Ubuntu 20.04 x86_64 向けバイナリが生成されます。
-
-```shell
-$ python3 run.py ubuntu-20.04_x86_64
-```
-
-うまくいかない場合は `rm -rf _source _build _install && python3 run.py ubuntu-20.04_x86_64` を試してみてください。
-
-
 ## Ubuntu 22.04 (x86_64) 向けバイナリを作成する
 
 build ディレクトリ以下で `python3 run.py ubuntu-22.04_x86_64` と打つことで Zakuro の Ubuntu 22.04 x86_64 向けバイナリが生成されます。
@@ -32,3 +21,14 @@ $ python3 run.py ubuntu-22.04_x86_64
 ```
 
 うまくいかない場合は `rm -rf _source _build _install && python3 run.py ubuntu-22.04_x86_64` を試してみてください。
+
+## Ubuntu 24.04 (x86_64) 向けバイナリを作成する
+
+build ディレクトリ以下で `python3 run.py ubuntu-24.04_x86_64` と打つことで Zakuro の Ubuntu 24.04 x86_64 向けバイナリが生成されます。
+
+```shell
+$ python3 run.py ubuntu-24.04_x86_64
+```
+
+うまくいかない場合は `rm -rf _source _build _install && python3 run.py ubuntu-24.04_x86_64` を試してみてください。
+


### PR DESCRIPTION
現在の develop の run.py に合わせてビルド説明ドキュメントの Ubuntu 20.04 のビルド方法を削除して、24.04 を追加します。

---

This pull request includes updates to the build instructions in the `doc/BUILD.md` file. The changes primarily involve updating the instructions to reflect the creation of binaries for newer Ubuntu versions.

Updates to build instructions:

* Updated the instructions to create binaries for Ubuntu 22.04 instead of Ubuntu 20.04.
* Added instructions to create binaries for Ubuntu 24.04.