### PR TITLE
Lyra 用の設定を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,13 +37,13 @@
   - @melpon @voluntas @zztkm
 - [UPDATE] Blend2D, AsmJit を最新版に上げる
   - @melpon @torikizi @voluntas
+- [UPDATE] Lyra 用の設定を削除する
+  - 2024.1.0 で機能廃止済であるため残った設定を削除
+  - @miosakuma
 - [ADD] Ubuntu 24.04 のビルドを追加
   - @melpon
 - [ADD] `--degradation-preference` 引数を追加
   - @melpon
-- [FIX] Lyra 用の設定を削除する
-  - 2024.1.0 で機能廃止済であるため残った設定を削除
-  - @miosakuma
 
 ### misc
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@
   - @melpon
 - [ADD] `--degradation-preference` 引数を追加
   - @melpon
+- [FIX] Lyra 用の設定を削除する
+  - 2024.1.0 で機能廃止済であるため残った設定を削除
+  - @miosakuma
 
 ### misc
 

--- a/src/zakuro.h
+++ b/src/zakuro.h
@@ -57,10 +57,6 @@ struct ZakuroConfig {
   // 空文字の場合コーデックは Sora 側で決める
   std::string sora_video_codec_type = "";
   std::string sora_audio_codec_type = "";
-  // Lyra 用の設定
-  int sora_audio_codec_lyra_bit_rate = 0;
-  std::optional<bool> sora_audio_codec_lyra_usedtx;
-  bool sora_check_lyra_version = false;
   // 0 の場合ビットレートは Sora 側で決める
   int sora_video_bit_rate = 0;
   int sora_audio_bit_rate = 0;


### PR DESCRIPTION
- [FIX] Lyra 用の設定を削除する
  - 2024.1.0 で機能廃止済であるため残った設定を削除

---

This pull request includes changes to remove deprecated settings for Lyra and update the documentation accordingly. The most important changes are summarized below:

### Removal of Lyra settings:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R44-R46): Deleted the Lyra settings section as the feature has been discontinued in version 2024.1.0.
* [`src/zakuro.h`](diffhunk://#diff-b51e47cde714d3f5cddf1b28cf3e86e3729af06b507fe3ef6496d42df73ba6b3L60-L63): Removed the Lyra-specific configuration parameters (`sora_audio_codec_lyra_bit_rate`, `sora_audio_codec_lyra_usedtx`, and `sora_check_lyra_version`).