### PR TITLE
スキーマバリデーションを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [ADD] signaling URL のバリデーションを追加
+  - signaling URL が ws:// または wss:// で始まらない場合はエラーを出力
+  - @voluntas
 - [ADD] H.265 コーデックサポートを追加
   - `--sora-video-codec-type` に H265 を追加
   - `--sora-video-h265-params` オプションを追加

--- a/src/zakuro.cpp
+++ b/src/zakuro.cpp
@@ -450,6 +450,15 @@ int Zakuro::Run() {
 
   vc_config.context = sora::SoraClientContext::Create(context_config);
 
+  // signaling URL のバリデーション
+  for (const auto& url : config_.sora_signaling_urls) {
+    if (url.find("wss://") != 0 && url.find("ws://") != 0) {
+      std::cerr << "[" << config_.name << "] Error: Invalid signaling URL: " << url << std::endl;
+      std::cerr << "Signaling URL must start with 'ws://' or 'wss://'" << std::endl;
+      return 1;
+    }
+  }
+
   sora_config.sora_client = ZakuroVersion::GetClientName();
   sora_config.insecure = config_.insecure;
   sora_config.client_cert = config_.client_cert;


### PR DESCRIPTION
This pull request introduces a new validation feature for signaling URLs to ensure they start with `ws://` or `wss://`. It also updates the documentation to reflect this change.

### Validation Feature:

* **Signaling URL Validation**: Added a validation step in the `Zakuro::Run()` method to check that all signaling URLs in `config_.sora_signaling_urls` start with `ws://` or `wss://`. If a URL does not meet this requirement, an error message is displayed, and the program exits with a non-zero status. (`src/zakuro.cpp`, [src/zakuro.cppR453-R461](diffhunk://#diff-09fcbde26f3f370a291e7c74d9049ef424cc05a502ac64ac702ad2c3027f65d4R453-R461))

### Documentation Update:

* **CHANGES.md**: Updated the changelog to include the addition of signaling URL validation, specifying the error output for invalid URLs. (`CHANGES.md`, [CHANGES.mdR14-R16](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16))