### PR TITLE
DataChannel でカスタムデータを送信できるようにする

### DIFF
--- a/src/scenario_player.h
+++ b/src/scenario_player.h
@@ -32,6 +32,7 @@ struct ScenarioData {
     std::string label;
     int min_size;
     int max_size;
+    std::shared_ptr<std::string> data;  // nullptr の場合は BinaryPool で自動生成
   };
   struct OpDisconnect {};
   struct OpReconnect {};
@@ -67,9 +68,12 @@ struct ScenarioData {
         loop_op_index});
   }
   void PlayVoiceNumberClient() { ops.push_back(OpPlayVoiceNumberClient()); }
-  void SendDataChannelMessage(std::string label, int min_size, int max_size) {
+  void SendDataChannelMessage(std::string label,
+                              int min_size,
+                              int max_size,
+                              std::shared_ptr<std::string> data = nullptr) {
     ops.push_back(
-        OpSendDataChannelMessage{std::move(label), min_size, max_size});
+        OpSendDataChannelMessage{std::move(label), min_size, max_size, data});
   }
   void Disconnect() { ops.push_back(OpDisconnect()); }
   void Reconnect() { ops.push_back(OpReconnect()); }
@@ -172,40 +176,52 @@ class ScenarioPlayer {
       }
       case ScenarioData::OP_SEND_DATA_CHANNEL_MESSAGE: {
         auto& op = boost::get<ScenarioData::OpSendDataChannelMessage>(opv);
-        std::string data =
-            config_.binary_pool->Get(op.min_size - 48, op.max_size - 48);
 
-        // 0-5 (6 bytes): ZAKURO
-        // 6-13 (8 bytes): 現在時刻（マイクロ秒単位の UNIX Time）
-        // 14-21 (8 bytes): ラベルごとに一意に増えていくカウンター
-        // 22-47 (26 bytes): Connection ID
-        char buf[48] = "ZAKURO";
-        char* p = buf + 6;
+        std::string payload;
+        if (op.data && !op.data->empty()) {
+          // カスタムデータをそのまま使用（ヘッダーなし）
+          payload = *op.data;
+          RTC_LOG(LS_INFO) << "Send DataChannel custom data size="
+                           << payload.size();
+        } else {
+          // 従来通り BinaryPool + 48バイトヘッダー
+          payload =
+              config_.binary_pool->Get(op.min_size - 48, op.max_size - 48);
 
-        uint64_t time = std::chrono::duration_cast<std::chrono::microseconds>(
-                            std::chrono::system_clock::now().time_since_epoch())
-                            .count();
-        for (int i = 0; i < 8; i++) {
-          p[i] = (char)((time >> ((7 - i) * 8)) & 0xff);
+          // 0-5 (6 bytes): ZAKURO
+          // 6-13 (8 bytes): 現在時刻（マイクロ秒単位の UNIX Time）
+          // 14-21 (8 bytes): ラベルごとに一意に増えていくカウンター
+          // 22-47 (26 bytes): Connection ID
+          char buf[48] = "ZAKURO";
+          char* p = buf + 6;
+
+          uint64_t time =
+              std::chrono::duration_cast<std::chrono::microseconds>(
+                  std::chrono::system_clock::now().time_since_epoch())
+                  .count();
+          for (int i = 0; i < 8; i++) {
+            p[i] = (char)((time >> ((7 - i) * 8)) & 0xff);
+          }
+          p += 8;
+
+          auto& counter = dc_counter_[op.label];
+          for (int i = 0; i < 8; i++) {
+            p[i] = (char)((counter >> ((7 - i) * 8)) & 0xff);
+          }
+          p += 8;
+
+          auto conn_id = (*config_.vcs)[client_id]->GetStats().connection_id;
+          memcpy(p, conn_id.c_str(), std::min<int>(conn_id.size(), 26));
+
+          payload.insert(payload.begin(), buf, buf + sizeof(buf));
+
+          RTC_LOG(LS_INFO) << "Send DataChannel unixtime(us)=" << time
+                           << " counter=" << counter
+                           << " connection_id=" << conn_id;
+          counter += 1;
         }
-        p += 8;
 
-        auto& counter = dc_counter_[op.label];
-        for (int i = 0; i < 8; i++) {
-          p[i] = (char)((counter >> ((7 - i) * 8)) & 0xff);
-        }
-        p += 8;
-
-        auto conn_id = (*config_.vcs)[client_id]->GetStats().connection_id;
-        memcpy(p, conn_id.c_str(), std::min<int>(conn_id.size(), 26));
-
-        data.insert(data.begin(), buf, buf + sizeof(buf));
-
-        RTC_LOG(LS_INFO) << "Send DataChannel unixtime(us)=" << time
-                         << " counter=" << counter
-                         << " connection_id=" << conn_id;
-        (*config_.vcs)[client_id]->SendMessage(op.label, data);
-        counter += 1;
+        (*config_.vcs)[client_id]->SendMessage(op.label, payload);
         break;
       }
       case ScenarioData::OP_DISCONNECT: {

--- a/src/zakuro.cpp
+++ b/src/zakuro.cpp
@@ -42,6 +42,7 @@ struct DataChannels {
     int interval = 500;
     int size_min = MESSAGE_SIZE_MIN;
     int size_max = MESSAGE_SIZE_MIN;
+    std::string data;  // カスタムデータ（空の場合は BinaryPool を使用）
   };
   std::vector<Channel> channels;
   std::vector<sora::SoraSignalingConfig::DataChannel> schannels;
@@ -153,6 +154,19 @@ static bool ParseDataChannels(boost::json::value data_channels,
 
     if (ch.size_min > ch.size_max) {
       ch.size_max = ch.size_min;
+    }
+
+    // data
+    {
+      auto it = obj.find("data");
+      if (it != obj.end()) {
+        ch.data = boost::json::serialize(it->value());
+        if (ch.data.size() > MESSAGE_SIZE_MAX) {
+          std::cerr << "data size exceeds MESSAGE_SIZE_MAX" << std::endl;
+          return false;
+        }
+        obj.erase(it);
+      }
     }
 
     // boost::optional<bool> ordered;
@@ -520,7 +534,11 @@ int Zakuro::Run() {
     for (const auto& ch : dcs.channels) {
       ScenarioData sd;
       sd.Sleep(ch.interval, ch.interval);
-      sd.SendDataChannelMessage(ch.label, ch.size_min, ch.size_max);
+      std::shared_ptr<std::string> data;
+      if (!ch.data.empty()) {
+        data = std::make_shared<std::string>(ch.data);
+      }
+      sd.SendDataChannelMessage(ch.label, ch.size_min, ch.size_max, data);
       dcs_data.push_back(std::make_tuple("scenario-dcs-" + ch.label, sd));
     }
 


### PR DESCRIPTION
data-channels の設定で data フィールドを指定すると、指定した JSON データをシリアライズして送信する。data が未指定の場合は従来通り BinaryPool + 48バイトヘッダーで送信する。