### PR TITLE
macOS ビルドで Boost.Asio の std::atomic::wait 利用を無効化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
   - WEBRTC_BUILD_VERSION を `m148.7778.4.0` に上げる
   - CMAKE_VERSION を `4.3.2` に上げる
   - BOOST_VERSION を　`1.91.0` に上げる
+  - macOS ビルドで Boost.Asio の `std::atomic::wait` 利用を無効化する
+    - Boost 1.91.0 では macOS 14.4 以降で Asio の `kqueue_reactor` が `std::atomic::wait` ベースの `atomic_slim_mutex` を利用するようになっており、 Sora C++ SDK はこれを無効化している
+    - Zakuro 側でも同じように無効化するため `BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を定義する
+    - 定義がずれると Boost.Asio の内部実装が食い違い、接続時にクラッシュやハングが発生する可能性がある
   - @torikizi
 - [UPDATE] AudioDeviceBuffer の変更に追随し、初期化時に env_ を渡すよう修正する
   - libwebrtc アップデートによって AudioDeviceBuffer が env を直接参照するようになったため

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,5 +181,11 @@ if (ZAKURO_PLATFORM STREQUAL "macos_arm64")
   target_link_options(zakuro PRIVATE -ObjC)
   set_target_properties(zakuro PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
+  # Boost 1.91.0 では macOS 14.4 以降で Asio の kqueue_reactor が
+  # std::atomic::wait ベースの atomic_slim_mutex を使うようになった。
+  # Sora C++ SDK はこれを無効化しているため、 Zakuro でも同じマクロを定義する。
+  # 定義がずれると Boost.Asio の内部実装が食い違い、接続時にクラッシュやハングが発生する可能性がある。
+  target_compile_definitions(zakuro PRIVATE BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT)
+
 elseif (ZAKURO_PLATFORM STREQUAL "ubuntu-20.04_x86_64" OR ZAKURO_PLATFORM STREQUAL "ubuntu-22.04_x86_64" OR ZAKURO_PLATFORM STREQUAL "ubuntu-24.04_x86_64")
 endif()


### PR DESCRIPTION
Sora C++ SDK の 2026.2.0-canary.10 で無効にした macOS の Boost の設定を Zakuro でも無効にする必要があるため、修正しました。